### PR TITLE
Added company name & tax code to UpdateOrderInformation

### DIFF
--- a/src/Vendr.Checkout/Web/Controllers/VendrCheckoutSurfaceController.cs
+++ b/src/Vendr.Checkout/Web/Controllers/VendrCheckoutSurfaceController.cs
@@ -102,6 +102,9 @@ namespace Vendr.Checkout.Web.Controllers
                             { VendrConstants.Properties.Customer.EmailPropertyAlias, model.Email },
                             { "marketingOptIn", model.MarketingOptIn ? "1" : "0" },
 
+                            { "customerCompany", model.CompanyName },
+                            { "taxCode", model.TaxCode },
+
                             { VendrConstants.Properties.Customer.FirstNamePropertyAlias, model.BillingAddress.FirstName },
                             { VendrConstants.Properties.Customer.LastNamePropertyAlias, model.BillingAddress.LastName },
                             { "billingAddressLine1", model.BillingAddress.Line1 },

--- a/src/Vendr.Checkout/Web/Dtos/VendrUpdateOrderInformationDto.cs
+++ b/src/Vendr.Checkout/Web/Dtos/VendrUpdateOrderInformationDto.cs
@@ -6,6 +6,10 @@
 
         public bool MarketingOptIn { get; set; }
 
+        public string CompanyName { get; set; }
+
+        public string TaxCode { get; set; }
+
         public VendrOrderAddressDto BillingAddress { get; set; }
 
         public VendrOrderAddressDto ShippingAddress { get; set; }

--- a/src/Vendr.Checkout/Web/UI/App_Plugins/VendrCheckout/Views/VendrCheckoutInformationPage.cshtml
+++ b/src/Vendr.Checkout/Web/UI/App_Plugins/VendrCheckout/Views/VendrCheckoutInformationPage.cshtml
@@ -53,6 +53,15 @@
 
     <h3 class="text-xl font-medium mb-4 mt-8">Billing Address</h3>
 
+    @*
+    <div class="flex -mx-1">
+        <input name="companyName" type="text" placeholder="Company name" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full"
+            value="@(currentOrder.Properties["customerCompany"])" />
+        <input name="taxCode" type="text" placeholder="Tax code" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full"
+            value="@(currentOrder.Properties["taxCode"])" />
+    </div>
+	*@
+
     <div class="flex -mx-1">
         <input name="billingAddress.Firstname" type="text" placeholder="First name" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full"
                value="@(currentOrder.CustomerInfo.FirstName)" required />


### PR DESCRIPTION
It would be good to have  `customerCompany` & `taxCode` in `UpdateOrderInformation`. Just In case you would want to use them. I added the input fields commented out in `VendrCheckoutInformationPage.cshtml` , just to show how you would add them later