### PR TITLE
Add alias on property groups so install doesn't fail

### DIFF
--- a/src/Vendr.Checkout/Pipeline/Tasks/CreateVendrCheckoutDocumentTypesTask.cs
+++ b/src/Vendr.Checkout/Pipeline/Tasks/CreateVendrCheckoutDocumentTypesTask.cs
@@ -105,6 +105,7 @@ namespace Vendr.Checkout.Pipeline.Tasks
                     x.PropertyGroups = new PropertyGroupCollection(new[]{
                         new PropertyGroup(new PropertyTypeCollection(true, checkoutStepProps)) {
                             Name = "Settings",
+                            Alias = "Settings",
                             SortOrder =100
                         }
                     });
@@ -123,6 +124,7 @@ namespace Vendr.Checkout.Pipeline.Tasks
                     : new PropertyGroup(new PropertyTypeCollection(true, checkoutStepProps)) 
                     {
                         Name = "Settings",
+                        Alias = "Settings",
                         SortOrder =100
                     };
 
@@ -223,6 +225,7 @@ namespace Vendr.Checkout.Pipeline.Tasks
                     x.PropertyGroups = new PropertyGroupCollection(new[]{
                         new PropertyGroup(new PropertyTypeCollection(true, checkoutPageProps)) {
                             Name = "Settings",
+                            Alias = "Settings",
                             SortOrder = 50
                         }
                     });
@@ -239,6 +242,7 @@ namespace Vendr.Checkout.Pipeline.Tasks
                     : new PropertyGroup(new PropertyTypeCollection(true, checkoutPageProps))
                     {
                         Name = "Settings",
+                        Alias = "Settings",
                         SortOrder = 100
                     };
 


### PR DESCRIPTION
In the Umbraco core, it looks like PropertyGroups throw an exception now if the alias isn't set.  It used to set it based on the name, but looks like that changed in 8.17, my guess is part of the tabs enhancement. 

https://github.com/umbraco/Umbraco-CMS/blob/e5549b75330f488c351120d7e26d78b22e5f346f/src/Umbraco.Core/Models/PropertyGroupCollection.cs#L93

This sets the alias to match the name.  

I ran into this issue while trying to install vendr.Checkout on v9 today and would get an error "Set an alias before adding the property group."   I downloaded the repo and updated this code to get the install to work.   

I'm not really sure how you track code, but I figured I'd throw my changes up here for reference.