### PR TITLE
Improving checkout translations

### DIFF
--- a/src/Vendr.Checkout/Web/Controllers/VendrCheckoutSurfaceController.cs
+++ b/src/Vendr.Checkout/Web/Controllers/VendrCheckoutSurfaceController.cs
@@ -41,7 +41,7 @@ namespace Vendr.Checkout.Web.Controllers
             }
             catch (ValidationException ex)
             {
-                ModelState.AddModelError("", "Failed to redeem discount code: " + ex.Message);
+                ModelState.AddModelError("", string.Format(Umbraco.GetDictionaryValue("VendrCheckout.Information.InvalidDiscountGiftCode", "Failed to redeem discount code: {0}"), ex.Message));
 
                 return IsAjaxRequest()
                     ? (ActionResult)Json(new { success = false, errors = ModelState.Values.SelectMany(x => x.Errors).Select(x => x.ErrorMessage) })

--- a/src/Vendr.Checkout/Web/Controllers/VendrCheckoutSurfaceController.cs
+++ b/src/Vendr.Checkout/Web/Controllers/VendrCheckoutSurfaceController.cs
@@ -41,7 +41,7 @@ namespace Vendr.Checkout.Web.Controllers
             }
             catch (ValidationException ex)
             {
-                ModelState.AddModelError("code", "Failed to redeem discount code: "+ ex.Message);
+                ModelState.AddModelError("", "Failed to redeem discount code: " + ex.Message);
 
                 return IsAjaxRequest()
                     ? (ActionResult)Json(new { success = false, errors = ModelState.Values.SelectMany(x => x.Errors).Select(x => x.ErrorMessage) })

--- a/src/Vendr.Checkout/Web/UI/App_Plugins/VendrCheckout/Views/Partials/VendrCheckoutPrevNext.cshtml
+++ b/src/Vendr.Checkout/Web/UI/App_Plugins/VendrCheckout/Views/Partials/VendrCheckoutPrevNext.cshtml
@@ -9,11 +9,11 @@
 <div class="flex flex-col-reverse items-center justify-between mt-8 md:flex-row">
     @if (prevStep != null)
     {
-        <div><a href="@(prevStep.Url)" class="text-@(themeColor) hover:text-gray-900 hover:underline"><i class="fa fa-angle-left"></i> @string.Format(Umbraco.GetDictionaryValue("VendrCheckout.Navigation.ReturnTo", "Return to "), prevStep.Name)</a></div>
+        <div><a href="@(prevStep.Url)" class="text-@(themeColor) hover:text-gray-900 hover:underline"><i class="fa fa-angle-left"></i> @string.Format(Umbraco.GetDictionaryValue("VendrCheckout.Navigation.ReturnTo", "Return to {0}"), prevStep.Name.ToLower())</a></div>
     }
     else if (backPage != null)
     {
-        <div><a href="@(backPage.Url)" class="text-@(themeColor) hover:text-gray-900 hover:underline"><i class="fa fa-angle-left"></i> @string.Format(Umbraco.GetDictionaryValue("VendrCheckout.Navigation.ReturnTo", "Return to "), backPage.Name)</a></div> }
+        <div><a href="@(backPage.Url)" class="text-@(themeColor) hover:text-gray-900 hover:underline"><i class="fa fa-angle-left"></i> @string.Format(Umbraco.GetDictionaryValue("VendrCheckout.Navigation.ReturnTo", "Return to {0}"), backPage.Name.ToLower())</a></div> }
     else
     {
         <div></div>
@@ -21,7 +21,7 @@
     @if (nextStep != null)
     {
         <div class="mb-4 w-full md:mb-0 md:w-auto">
-            <button id="continue" class="bg-@(themeColor) text-white px-4 py-4 w-full rounded hover:bg-gray-900" type="submit">@string.Format(Umbraco.GetDictionaryValue("VendrCheckout.Navigation.ContinueTo", "Continue to"), nextStep.Name)</button>
+            <button id="continue" class="bg-@(themeColor) text-white px-4 py-4 w-full rounded hover:bg-gray-900" type="submit">@string.Format(Umbraco.GetDictionaryValue("VendrCheckout.Navigation.ContinueTo", "Continue to {0}"), nextStep.Name.ToLower())</button>
         </div>
     }
 </div>


### PR DESCRIPTION
Fixing a couple of issues reported by a client with Vendr Checkout translations.

1. As the master template prevents property model errors from being rendered (`@Html.ValidationSummary(true)`) the invalid discount code message just displayed an empty box - I have set the property to an empty string for this error message

2. Upon fixing the invalid discount code message we discovered it wasn't translatable via a dictionary value - I have added a `VendrCheckout.Information.InvalidDiscountGiftCode` dictionary key that can be used to override the default

3. The default values for the prev / next buttons did not include the step name - the `{0}` placeholder had been missed off the dictionary fallback value. I see this was recently fixed in [d732121](https://github.com/vendrhub/vendr-checkout/commit/d73212110d49d4a702d6b551fad2b03a2656ffbc) for Vendr Checkout V2.

4. The step name in the prev / next buttons usually has a capital letter at the start, given as it is a node name. This looks a bit odd, e.g. "Continue to Shipping method", so I have `.ToLower()`'d step names for a more natural read.

I appreciate this PR is targeted to Vendr Checkout V1, simply because this is what affects our client. It should be easy to merge these changes up to Vendr Checkout V2 also!