### PR TITLE
Null check store logo

### DIFF
--- a/src/Vendr.Checkout/Web/UI/App_Plugins/VendrCheckout/Views/VendrCheckoutMaster.cshtml
+++ b/src/Vendr.Checkout/Web/UI/App_Plugins/VendrCheckout/Views/VendrCheckoutMaster.cshtml
@@ -16,6 +16,7 @@
     var checkoutPage = Model.GetCheckoutPage();
     var themeColor = Model.GetThemeColor();
 
+    var storeLogo = checkoutPage.Value<IPublishedContent>("vendrStoreLogo");
 }
 <html lang="@UICulture">
 <head>
@@ -40,9 +41,9 @@
         <div class="relative flex flex-col min-h-full max-w-6xl mx-auto lg:flex-row-reverse lg:flex-row">
 
             <div class="bg-white p-8 text-center lg:hidden">
-                @if (checkoutPage.HasValue("vendrStoreLogo"))
+                @if (storeLogo != null)
                 {
-                    <a href="/"><img src="@(Url.GetCropUrl(checkoutPage.Value<IPublishedContent>("vendrStoreLogo"), 200, 200, imageCropMode: ImageCropMode.Max))" class="inline-block" alt="@(store.Name)" /></a>
+                    <a href="/"><img src="@(Url.GetCropUrl(storeLogo, 200, 200, imageCropMode: ImageCropMode.Max))" class="inline-block" alt="@(store.Name)" /></a>
                 }
                 else
                 {
@@ -158,10 +159,9 @@
                 <div class="hidden lg:block">
 
                     <div class="text-center mb-4">
-                        @if (checkoutPage.HasValue("vendrStoreLogo"))
+                        @if (storeLogo != null)
                         {
-                            <a href="/"><img src="@(Url.GetCropUrl(checkoutPage.Value<IPublishedContent>("vendrStoreLogo"), 200, 100, imageCropMode: ImageCropMode.Max))" class="inline-block" alt="@(store.Name)" /></a>
-
+                            <a href="/"><img src="@(Url.GetCropUrl(storeLogo, 200, 100, imageCropMode: ImageCropMode.Max))" class="inline-block" alt="@(store.Name)" /></a>
                         }
                         else
                         {


### PR DESCRIPTION
Fixing a small issue reported by a client with Vendr Checkout.

In the Vendr Checkout settings when no store logo is selected, or if the media item is deleted, the Checkout pages throw an error.

This PR adds some better defensive code around the store logo in the VendrCheckoutMaster view. Unfortunately in V8 `HasValue` can't be trusted!

I appreciate this PR is targeted to Vendr Checkout V1, simply because this is what affects our client. It should be easy to merge these changes up to Vendr Checkout V2 also!