### PR TITLE
Use correct country in email

### DIFF
--- a/src/Vendr.Checkout/Web/UI/App_Plugins/VendrCheckout/views/emails/VendrCheckoutOrderConfirmationEmail.cshtml
+++ b/src/Vendr.Checkout/Web/UI/App_Plugins/VendrCheckout/views/emails/VendrCheckoutOrderConfirmationEmail.cshtml
@@ -118,7 +118,7 @@
                                                         Model.Properties["shippingAddressLine2"],
                                                         Model.Properties["shippingCity"],
                                                         Model.Properties["shippingZipCode"],
-                                                        paymentCountry.Name,
+                                                        shippingCountry?.Name,
                                                         shippingRegion != null ? shippingRegion.Name : null
                                                     };
                                                     @Html.Raw(string.Join("<br />", shippingParts.Where(x => !string.IsNullOrWhiteSpace(x))))


### PR DESCRIPTION
Use the `shippingCountry` when generating the confirmation email